### PR TITLE
Add configurable controller profiles and port maps

### DIFF
--- a/src/EVOX1.cpp
+++ b/src/EVOX1.cpp
@@ -1,16 +1,29 @@
 #include <Evo.h>
 
+static EvoControllerConfigManager &cfgMgr = EvoControllerConfigManager::getInstance();
+static const EvoControllerConfig &cfg()
+{
+    return cfgMgr.getConfig();
+}
+
 void EVOX1::begin()
 {
-    i2CDevice.selectChannel(SSD1309_CHANNEL);
-    display.begin();
-    this->setFontSize(8);
+    i2CDevice.selectChannel(cfg().displayChannel);
+    if (cfg().hasDisplay)
+    {
+        display.begin();
+        this->setFontSize(8);
+    }
 
     charger.begin();
     evoPWMDriver.begin();
 
-    rgb.begin();
-    setRGB(0, 0, 0);
+    if (cfg().hasNeoPixel)
+    {
+        rgb.setPin(cfg().pixelPin);
+        rgb.begin();
+        setRGB(0, 0, 0);
+    }
 }
 
 float EVOX1::getBattery()
@@ -45,23 +58,23 @@ void EVOX1::playTone(uint frequency, int duration, bool blocking)
     }
     else if (duration == -1)
     {
-        tone(BUZZER_PIN, frequency, 0);
+        if (cfg().hasBuzzer) tone(cfg().buzzerPin, frequency, 0);
         return;
     }
     else
     {
-        tone(BUZZER_PIN, frequency, duration);
+        if (cfg().hasBuzzer) tone(cfg().buzzerPin, frequency, duration);
         if (blocking)
         {
             delay(duration);
-            noTone(BUZZER_PIN);
+            if (cfg().hasBuzzer) noTone(cfg().buzzerPin);
         }
     }
 }
 
 void EVOX1::stopTone()
 {
-    noTone(BUZZER_PIN);
+    if (cfg().hasBuzzer) noTone(cfg().buzzerPin);
 }
 
 void EVOX1::flipDisplayOrientation(bool flip)
@@ -103,13 +116,13 @@ void EVOX1::setFontSize(uint8_t size)
 
 void EVOX1::clearDisplay()
 {
-    i2CDevice.selectChannel(SSD1309_CHANNEL);
+    i2CDevice.selectChannel(cfg().displayChannel);
     display.clearBuffer();
 }
 
 void EVOX1::writeToDisplay(int value, int x, int y, bool clear, bool draw)
 {
-    i2CDevice.selectChannel(SSD1309_CHANNEL);
+    i2CDevice.selectChannel(cfg().displayChannel);
     if (clear)
     {
         this->clearDisplay();
@@ -125,7 +138,7 @@ void EVOX1::writeToDisplay(int value, int x, int y, bool clear, bool draw)
 
 void EVOX1::writeToDisplay(double f, int x, int y, bool clear, bool draw)
 {
-    i2CDevice.selectChannel(SSD1309_CHANNEL);
+    i2CDevice.selectChannel(cfg().displayChannel);
     if (clear)
     {
         this->clearDisplay();
@@ -141,7 +154,7 @@ void EVOX1::writeToDisplay(double f, int x, int y, bool clear, bool draw)
 
 void EVOX1::writeToDisplay(const char *c, int x, int y, bool clear, bool draw)
 {
-    i2CDevice.selectChannel(SSD1309_CHANNEL);
+    i2CDevice.selectChannel(cfg().displayChannel);
     if (clear)
     {
         this->clearDisplay();
@@ -170,7 +183,7 @@ void EVOX1::writeLineToDisplay(const char *c, int line, bool clear, bool draw)
 
 void EVOX1::drawDisplay()
 {
-    i2CDevice.selectChannel(SSD1309_CHANNEL);
+    i2CDevice.selectChannel(cfg().displayChannel);
     display.sendBuffer();
 }
 
@@ -178,12 +191,12 @@ void EVOX1::waitForButton()
 {
     if (pinState != BUTTON_STATE)
     {
-        pinMode(BUTTON_PIN, INPUT_PULLUP);
+        pinMode(cfg().buttonPin, INPUT_PULLUP);
         pinState = BUTTON_STATE;
     }
-    while (digitalRead(BUTTON_PIN))
+    while (digitalRead(cfg().buttonPin))
         ;
-    while (!digitalRead(BUTTON_PIN))
+    while (!digitalRead(cfg().buttonPin))
         ;
 }
 
@@ -191,10 +204,10 @@ void EVOX1::waitForPress(int debouncems)
 {
     if (pinState != BUTTON_STATE)
     {
-        pinMode(BUTTON_PIN, INPUT_PULLUP);
+        pinMode(cfg().buttonPin, INPUT_PULLUP);
         pinState = BUTTON_STATE;
     }
-    while (digitalRead(BUTTON_PIN))
+    while (digitalRead(cfg().buttonPin))
         ;
     delay(debouncems);
 }
@@ -203,10 +216,10 @@ void EVOX1::waitForRelease(int debouncems)
 {
     if (pinState != BUTTON_STATE)
     {
-        pinMode(BUTTON_PIN, INPUT_PULLUP);
+        pinMode(cfg().buttonPin, INPUT_PULLUP);
         pinState = BUTTON_STATE;
     }
-    while (!digitalRead(BUTTON_PIN))
+    while (!digitalRead(cfg().buttonPin))
         ;
     delay(debouncems);
 }
@@ -215,13 +228,13 @@ void EVOX1::waitForBump(int debouncems)
 {
     if (pinState != BUTTON_STATE)
     {
-        pinMode(BUTTON_PIN, INPUT_PULLUP);
+        pinMode(cfg().buttonPin, INPUT_PULLUP);
         pinState = BUTTON_STATE;
     }
-    while (digitalRead(BUTTON_PIN))
+    while (digitalRead(cfg().buttonPin))
         ;
     delay(debouncems);
-    while (!digitalRead(BUTTON_PIN))
+    while (!digitalRead(cfg().buttonPin))
         ;
     delay(debouncems);
 }
@@ -230,14 +243,18 @@ ButtonState EVOX1::getButton()
 {
     if (pinState != BUTTON_STATE)
     {
-        pinMode(BUTTON_PIN, INPUT_PULLUP);
+        pinMode(cfg().buttonPin, INPUT_PULLUP);
         pinState = BUTTON_STATE;
     }
-    return static_cast<ButtonState>(digitalRead(BUTTON_PIN));
+    return static_cast<ButtonState>(digitalRead(cfg().buttonPin));
 }
 
 void EVOX1::setRGB(int r, int g, int b)
 {
+    if (!cfg().hasNeoPixel)
+    {
+        return;
+    }
     this->pinState = RGB_LED_STATE;
     rgb.setPixelColor(0, rgb.Color(r, g, b));
     rgb.show();
@@ -263,4 +280,39 @@ int EVOX1::scanI2CChannel(I2CChannel channel, uint8_t *addresses, int maxAddress
         }
     }
     return count;
+}
+
+void EVOX1::setControllerVariant(EvoControllerVariant variant)
+{
+    cfgMgr.setVariant(variant);
+}
+
+void EVOX1::setCustomControllerConfig(const EvoControllerConfig &config)
+{
+    cfgMgr.setCustomConfig(config);
+}
+
+const EvoControllerConfig &EVOX1::getControllerConfig() const
+{
+    return cfg();
+}
+
+uint8_t EVOX1::getMotorPortCount() const
+{
+    return cfg().motorPortCount;
+}
+
+uint8_t EVOX1::getSensorPortCount() const
+{
+    return cfg().sensorPortCount;
+}
+
+uint8_t EVOX1::getServoPortCount() const
+{
+    return cfg().servoPortCount;
+}
+
+uint8_t EVOX1::getI2CPortCount() const
+{
+    return cfg().i2cPortCount;
 }

--- a/src/EVOX1.h
+++ b/src/EVOX1.h
@@ -6,7 +6,7 @@
 #ifndef EVOX1_H
 #define EVOX1_H
 #include <Arduino.h>
-#include <helper/X1pins.h>
+#include <helper/EvoControllerConfig.h>
 #include <helper/Tones.h>
 #include <helper/EvoI2CDevice.h>
 #include <helper/EvoPWMDriver.h>
@@ -83,7 +83,7 @@ public:
      * @brief Gets the singleton instance of EVOX1.
      */
     EVOX1() : display(U8G2_R0, U8X8_PIN_NONE),
-              rgb(1, PIXEL_PIN, NEO_GRBW + NEO_KHZ800)
+              rgb(1, 0, NEO_GRBW + NEO_KHZ800)
     {
     }
 
@@ -111,6 +111,24 @@ public:
      * @brief Initializes the EVOX1 board and its peripherals.
      */
     void begin();
+
+    /**
+     * @brief Configure predefined controller variant.
+     */
+    void setControllerVariant(EvoControllerVariant variant);
+
+    /**
+     * @brief Configure a fully custom controller mapping.
+     */
+    void setCustomControllerConfig(const EvoControllerConfig &config);
+
+    const EvoControllerConfig &getControllerConfig() const;
+
+    uint8_t getMotorPortCount() const;
+    uint8_t getSensorPortCount() const;
+    uint8_t getServoPortCount() const;
+    uint8_t getI2CPortCount() const;
+
 
     /**
      * @brief Selects an I2C channel on the multiplexer.

--- a/src/helper/EvoControllerConfig.cpp
+++ b/src/helper/EvoControllerConfig.cpp
@@ -1,0 +1,112 @@
+#include "EvoControllerConfig.h"
+
+EvoControllerConfigManager &EvoControllerConfigManager::getInstance()
+{
+    static EvoControllerConfigManager instance;
+    return instance;
+}
+
+EvoControllerConfigManager::EvoControllerConfigManager()
+{
+    _activeConfig = createEvoX1EConfig();
+}
+
+const EvoControllerConfig &EvoControllerConfigManager::getConfig() const
+{
+    return _activeConfig;
+}
+
+void EvoControllerConfigManager::setVariant(EvoControllerVariant variant)
+{
+    _variant = variant;
+    switch (variant)
+    {
+    case EvoControllerVariant::EvoX1P:
+        _activeConfig = createEvoX1PConfig();
+        break;
+    case EvoControllerVariant::EvoX1R:
+        _activeConfig = createEvoX1RConfig();
+        break;
+    case EvoControllerVariant::Custom:
+        break;
+    case EvoControllerVariant::EvoX1E:
+    default:
+        _activeConfig = createEvoX1EConfig();
+        break;
+    }
+}
+
+void EvoControllerConfigManager::setCustomConfig(const EvoControllerConfig &config)
+{
+    _variant = EvoControllerVariant::Custom;
+    _activeConfig = config;
+}
+
+EvoControllerConfig EvoControllerConfigManager::createEvoX1EConfig() const
+{
+    EvoControllerConfig config;
+    config.name = "EvoX1E";
+    config.motorPortCount = 4;
+    config.sensorPortCount = 4;
+    config.servoPortCount = 8;
+    config.i2cPortCount = 8;
+    config.gpioPortCount = 8;
+
+    config.hasBuzzer = true;
+    config.hasNeoPixel = true;
+    config.hasDisplay = true;
+
+    config.buzzerPin = 11;
+    config.buttonPin = 14;
+    config.pixelPin = 14;
+    config.displayChannel = I2C8;
+
+    config.i2cSdaPin = 1;
+    config.i2cSclPin = 2;
+    config.muxAddress = 0x70;
+
+    config.motorPorts[0] = {14, 15, 47, 21};
+    config.motorPorts[1] = {13, 12, 38, 48};
+    config.motorPorts[2] = {11, 10, 40, 39};
+    config.motorPorts[3] = {9, 8, 42, 41};
+
+    config.sensorPorts[0] = {10, 9, 10};
+    config.sensorPorts[1] = {8, 3, 8};
+    config.sensorPorts[2] = {7, 6, 7};
+    config.sensorPorts[3] = {5, 4, 5};
+
+    for (uint8_t i = 0; i < config.servoPortCount; i++)
+    {
+        config.servoChannels[i] = i;
+    }
+
+    for (uint8_t i = 0; i < config.i2cPortCount; i++)
+    {
+        config.i2cChannels[i] = static_cast<I2CChannel>(i);
+    }
+
+    config.gpioPins[0] = 10;
+    config.gpioPins[1] = 9;
+    config.gpioPins[2] = 8;
+    config.gpioPins[3] = 3;
+    config.gpioPins[4] = 7;
+    config.gpioPins[5] = 6;
+    config.gpioPins[6] = 5;
+    config.gpioPins[7] = 4;
+
+    return config;
+}
+
+EvoControllerConfig EvoControllerConfigManager::createEvoX1PConfig() const
+{
+    EvoControllerConfig config = createEvoX1EConfig();
+    config.name = "EvoX1P";
+    return config;
+}
+
+EvoControllerConfig EvoControllerConfigManager::createEvoX1RConfig() const
+{
+    EvoControllerConfig config = createEvoX1EConfig();
+    config.name = "EvoX1R";
+    return config;
+}

--- a/src/helper/EvoControllerConfig.h
+++ b/src/helper/EvoControllerConfig.h
@@ -1,0 +1,86 @@
+#ifndef EVO_CONTROLLER_CONFIG_H
+#define EVO_CONTROLLER_CONFIG_H
+
+#include <Arduino.h>
+#include "EvoI2CDevice.h"
+
+constexpr uint8_t EVO_MAX_MOTOR_PORTS = 8;
+constexpr uint8_t EVO_MAX_SENSOR_PORTS = 8;
+constexpr uint8_t EVO_MAX_SERVO_PORTS = 16;
+constexpr uint8_t EVO_MAX_I2C_PORTS = 8;
+constexpr uint8_t EVO_MAX_GPIO_PORTS = 16;
+
+struct EvoMotorPortConfig
+{
+    uint8_t power1 = 0;
+    uint8_t power2 = 0;
+    uint8_t tach1 = 0;
+    uint8_t tach2 = 0;
+};
+
+struct EvoSensorPortConfig
+{
+    uint8_t txPin = 0;
+    uint8_t rxPin = 0;
+    uint8_t digitalPin = 0;
+};
+
+enum class EvoControllerVariant
+{
+    EvoX1E,
+    EvoX1P,
+    EvoX1R,
+    Custom,
+};
+
+struct EvoControllerConfig
+{
+    const char *name = "EvoX1E";
+
+    uint8_t motorPortCount = 0;
+    uint8_t sensorPortCount = 0;
+    uint8_t servoPortCount = 0;
+    uint8_t i2cPortCount = 0;
+    uint8_t gpioPortCount = 0;
+
+    bool hasBuzzer = false;
+    bool hasNeoPixel = false;
+    bool hasDisplay = true;
+
+    uint8_t buzzerPin = 0;
+    uint8_t buttonPin = 0;
+    uint8_t pixelPin = 0;
+    I2CChannel displayChannel = I2C8;
+
+    uint8_t i2cSdaPin = 1;
+    uint8_t i2cSclPin = 2;
+    uint8_t muxAddress = 0x70;
+
+    EvoMotorPortConfig motorPorts[EVO_MAX_MOTOR_PORTS];
+    EvoSensorPortConfig sensorPorts[EVO_MAX_SENSOR_PORTS];
+    uint8_t servoChannels[EVO_MAX_SERVO_PORTS];
+    I2CChannel i2cChannels[EVO_MAX_I2C_PORTS];
+    uint8_t gpioPins[EVO_MAX_GPIO_PORTS];
+};
+
+class EvoControllerConfigManager
+{
+public:
+    static EvoControllerConfigManager &getInstance();
+
+    const EvoControllerConfig &getConfig() const;
+    void setVariant(EvoControllerVariant variant);
+    void setCustomConfig(const EvoControllerConfig &config);
+
+private:
+    EvoControllerConfigManager();
+
+    EvoControllerConfig _activeConfig;
+    EvoControllerVariant _variant = EvoControllerVariant::EvoX1E;
+
+    EvoControllerConfig createEvoX1EConfig() const;
+    EvoControllerConfig createEvoX1PConfig() const;
+    EvoControllerConfig createEvoX1RConfig() const;
+};
+
+#endif

--- a/src/helper/EvoSensorPort.cpp
+++ b/src/helper/EvoSensorPort.cpp
@@ -5,25 +5,15 @@ static const char *TAG = "EvoSensorPort";
 EvoSensorPort::EvoSensorPort(SensorPort port) : _port(port)
 {
     // _port = port;
-    switch (_port)
+    const EvoControllerConfig &config = EvoControllerConfigManager::getInstance().getConfig();
+    uint8_t portIndex = static_cast<uint8_t>(_port);
+    if (portIndex >= config.sensorPortCount)
     {
-    case S1:
-        _rxPin = S12;
-        _txPin = S11;
-        break;
-    case S2:
-        _rxPin = S22;
-        _txPin = S21;
-        break;
-    case S3:
-        _rxPin = S32;
-        _txPin = S31;
-        break;
-    case S4:
-        _rxPin = S42;
-        _txPin = S41;
-        break;
+        portIndex = 0;
     }
+
+    _txPin = config.sensorPorts[portIndex].txPin;
+    _rxPin = config.sensorPorts[portIndex].rxPin;
     this->_serialMutex = xSemaphoreCreateMutex();
 }
 

--- a/src/helper/EvoSensorPort.h
+++ b/src/helper/EvoSensorPort.h
@@ -5,14 +5,18 @@
 #include <Arduino.h>
 #include <functional>
 #include "SoftwareSerial/SoftwareSerial.h"
-#include "X1pins.h"
+#include "EvoControllerConfig.h"
 
 enum SensorPort
 {
-    S1,
-    S2,
-    S3,
-    S4
+    S1 = 0,
+    S2 = 1,
+    S3 = 2,
+    S4 = 3,
+    S5 = 4,
+    S6 = 5,
+    S7 = 6,
+    S8 = 7
 };
 
 /**

--- a/src/motors/EvoMotor.cpp
+++ b/src/motors/EvoMotor.cpp
@@ -36,32 +36,21 @@ EvoMotor::EvoMotor(MotorPort motorPort, MotorType motorType, bool motorFlip)
         break;
     }
 
-    switch (_motorPort)
+    const EvoControllerConfig &config = EvoControllerConfigManager::getInstance().getConfig();
+    uint8_t portIndex = static_cast<uint8_t>(_motorPort);
+    if (portIndex >= config.motorPortCount)
     {
-    case M1:
-        if (_motorFlip)
-            _motorPins = {MOTOR11, MOTOR12, TACH12, TACH11};
-        else
-            _motorPins = {MOTOR12, MOTOR11, TACH11, TACH12};
-        break;
-    case M2:
-        if (_motorFlip)
-            _motorPins = {MOTOR22, MOTOR21, TACH22, TACH21};
-        else
-            _motorPins = {MOTOR21, MOTOR22, TACH21, TACH22};
-        break;
-    case M3:
-        if (!_motorFlip)
-            _motorPins = {MOTOR31, MOTOR32, TACH31, TACH32};
-        else
-            _motorPins = {MOTOR32, MOTOR31, TACH32, TACH31};
-        break;
-    case M4:
-        if (!_motorFlip)
-            _motorPins = {MOTOR41, MOTOR42, TACH41, TACH42};
-        else
-            _motorPins = {MOTOR42, MOTOR41, TACH42, TACH41};
-        break;
+        portIndex = 0;
+    }
+
+    const EvoMotorPortConfig &portConfig = config.motorPorts[portIndex];
+    if (_motorFlip)
+    {
+        _motorPins = {portConfig.power2, portConfig.power1, portConfig.tach2, portConfig.tach1};
+    }
+    else
+    {
+        _motorPins = {portConfig.power1, portConfig.power2, portConfig.tach1, portConfig.tach2};
     }
 }
 

--- a/src/motors/EvoMotor.h
+++ b/src/motors/EvoMotor.h
@@ -6,7 +6,7 @@
 #ifndef EVOMOTOR_H
 #define EVOMOTOR_H
 #include "../helper/EvoPWMDriver.h"
-#include "../helper/X1pins.h"
+#include "../helper/EvoControllerConfig.h"
 #include "../helper/ESP32Encoder/ESP32Encoder.h"
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
@@ -47,10 +47,14 @@ enum MotorType
  */
 enum MotorPort
 {
-    M1 = 8,
-    M2 = 10,
-    M3 = 12,
-    M4 = 14
+    M1 = 0,
+    M2 = 1,
+    M3 = 2,
+    M4 = 3,
+    M5 = 4,
+    M6 = 5,
+    M7 = 6,
+    M8 = 7
 };
 
 /**

--- a/src/motors/EvoServo.cpp
+++ b/src/motors/EvoServo.cpp
@@ -2,7 +2,13 @@
 
 EvoServo::EvoServo(ServoChannel servoChannel, ServoType servoType)
 {
-    _servoChannel = static_cast<uint8_t>(servoChannel);
+    uint8_t requestedChannel = static_cast<uint8_t>(servoChannel);
+    const EvoControllerConfig &config = EvoControllerConfigManager::getInstance().getConfig();
+    if (requestedChannel >= config.servoPortCount)
+    {
+        requestedChannel = 0;
+    }
+    _servoChannel = config.servoChannels[requestedChannel];
     switch (servoType)
     {
     case SG90:

--- a/src/motors/EvoServo.h
+++ b/src/motors/EvoServo.h
@@ -7,6 +7,7 @@
 #define EVO_SERVO_H
 
 #include "../helper/EvoPWMDriver.h"
+#include "../helper/EvoControllerConfig.h"
 
 /**
  * @enum ServoType
@@ -35,7 +36,15 @@ enum ServoChannel
     SERVO5 = 4, // Channel 4 on the multiplexer
     SERVO6 = 5, // Channel 5 on the multiplexer
     SERVO7 = 6, // Channel 6 on the multiplexer
-    SERVO8 = 7  // Channel 7 on the multiplexer
+    SERVO8 = 7,  // Channel 7 on the multiplexer
+    SERVO9 = 8,
+    SERVO10 = 9,
+    SERVO11 = 10,
+    SERVO12 = 11,
+    SERVO13 = 12,
+    SERVO14 = 13,
+    SERVO15 = 14,
+    SERVO16 = 15
 };
 
 /**

--- a/src/sensors/EV3TouchSensor.cpp
+++ b/src/sensors/EV3TouchSensor.cpp
@@ -2,21 +2,14 @@
 
 EV3TouchSensor::EV3TouchSensor(SensorPort port) : _port(port)
 {
-    switch (_port)
+    const EvoControllerConfig &config = EvoControllerConfigManager::getInstance().getConfig();
+    uint8_t portIndex = static_cast<uint8_t>(_port);
+    if (portIndex >= config.sensorPortCount)
     {
-    case S1:
-        _pin = S11;
-        break;
-    case S2:
-        _pin = S21;
-        break;
-    case S3:
-        _pin = S31;
-        break;
-    case S4:
-        _pin = S41;
-        break;
+        portIndex = 0;
     }
+
+    _pin = config.sensorPorts[portIndex].digitalPin;
     pinMode(_pin, INPUT_PULLDOWN);
 }
 int EV3TouchSensor::getButton()

--- a/src/sensors/EV3TouchSensor.h
+++ b/src/sensors/EV3TouchSensor.h
@@ -5,6 +5,7 @@
 #define EVO_EV3TOUCHSENSOR_H
 #include <Arduino.h>
 #include "../helper/EvoSensorPort.h"
+#include "../helper/EvoControllerConfig.h"
 
 /**
  * @class EV3TouchSensor


### PR DESCRIPTION
### Motivation
- Support multiple EvoX1 variants (EvoX1E, EvoX1P, EvoX1R) and custom controllers with different pin mappings and features (buzzer, NeoPixel, display, differing numbers of motor/servo/I2C/GPIO ports) instead of hardcoding EvoX1E macros.

### Description
- Introduced a controller configuration layer `EvoControllerConfig` plus `EvoControllerConfigManager` to hold per-controller feature flags, port counts and per-port pin/channel mappings (`src/helper/EvoControllerConfig.h`, `src/helper/EvoControllerConfig.cpp`).
- Added runtime APIs on `EVOX1` to select built-in variants or supply a custom mapping (`setControllerVariant`, `setCustomControllerConfig`) and getters for active port counts; updated `EVOX1` to use the active config for display channel, button, buzzer and NeoPixel handling (`src/EVOX1.h`, `src/EVOX1.cpp`).
- Refactored motor/servo/sensor code to resolve pins/channels from the active controller config instead of `X1pins.h`: expanded logical enums to support more ports (`M1..M8`, `S1..S8`, `SERVO1..SERVO16`) and map those to configured pins/channels in `EvoMotor`, `EvoServo`, `EvoSensorPort` and `EV3TouchSensor` (`src/motors/*`, `src/helper/EvoSensorPort.*`, `src/sensors/*`).
- Left EvoX1P/EvoX1R as aliases of EvoX1E by default and provided `Custom` variant so users can call `setCustomControllerConfig(...)` to provide exact mappings for other hardware.

### Testing
- Ran `git diff --check` to validate diffs and whitespace issues, which succeeded.
- Attempted to run a full build with `platformio run`, but the `platformio` command is not available in this environment so a full compile could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69c4c3787f8883339342e239e773c9d6)